### PR TITLE
Sometimes ARP fails

### DIFF
--- a/arp_ping.py
+++ b/arp_ping.py
@@ -8,17 +8,30 @@ import sys
 import argparse
 from scapy.all import *
 
-def get_mac(ip, interface):
-    result = ''
-    arp_request = Ether(src=get_if_hwaddr(interface),dst="ff:ff:ff:ff:ff:ff")/ARP(pdst=ip)
-    ans, unans = srp(arp_request, timeout=2, iface=interface, verbose=False)
-    if ans:
-        first_response = ans[0]
-        req, res = first_response
-        result = res.getlayer(Ether).src
+bcast_mac = 'ff:ff:ff:ff:ff:ff'
 
-    return result
+def get_mac(ip_addr, interface):
+    # arp_packet creation
+    interface_mac = get_if_hwaddr(interface)
+    eth_hdr = Ether(src=interface_mac, dst=bcast_mac, type=0x0806) # Ethernet header (Broadcast ethernet)
+    arp_hdr = ARP(op=ARP.who_has, pdst=ip_addr) # ARP header with 'who has this IP with MAC?'
+    padstr = '\x00' * (60 - len(eth_hdr) - len(arp_hdr))
+    pad = Padding(load=padstr) # a bunch of 0-bytes
+    arp_packet = eth_hdr/arp_hdr/pad
 
+    # Send ARP packets 5 times until it get correct response
+    for i in range(5):
+        response = srp1(arp_packet, iface=interface, verbose=0, timeout=5)
+        if response == None:
+            print("ARP faild. retransmitting", file=sys.stderr)
+            continue
+        else:
+            break
+
+    if response.op == 2:
+        return response.hwsrc
+    else:
+        return None
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Some packets may be dropped by the network when we send arp packets. If such thing happens arp_ping.py did not handled that. In order to get rid of this we continuously send ARP packets until a successful response come back.